### PR TITLE
fix: increase SMTP username and password character limit from 20 to 100

### DIFF
--- a/internal/models/setting.go
+++ b/internal/models/setting.go
@@ -371,8 +371,8 @@ func (v SMTP) Validate() error {
 		validation.Field(&v.Host, is.Host),
 		validation.Field(&v.Port, validation.Required, validation.Min(1), validation.Max(65535)),
 		// validation.Field(&v.Encryption),
-		validation.Field(&v.Username, validation.Length(3, 20)),
-		validation.Field(&v.Password, validation.Length(3, 20)),
+		validation.Field(&v.Username, validation.Length(3, 100)),
+		validation.Field(&v.Password, validation.Length(3, 100)),
 	)
 }
 

--- a/internal/models/setting_test.go
+++ b/internal/models/setting_test.go
@@ -210,17 +210,141 @@ func TestMail_Validate(t *testing.T) {
 
 func TestSMTP_Validate(t *testing.T) {
 	t.Parallel()
-	valid := SMTP{Host: "smtp.example.com", Port: 587, Username: "user", Password: "pass"}
-	if err := valid.Validate(); err != nil {
-		t.Errorf("valid smtp rejected: %v", err)
+
+	tests := []struct {
+		name      string
+		smtp      SMTP
+		wantError bool
+	}{
+		{
+			name: "valid smtp with short credentials",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "user",
+				Password: "pass",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid smtp with 3 char username (minimum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "abc",
+				Password: "password",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid smtp with 3 char password (minimum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "username",
+				Password: "abc",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid smtp with 50 char username",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: strings.Repeat("u", 50),
+				Password: "password",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid smtp with 100 char username (maximum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: strings.Repeat("u", 100),
+				Password: "password",
+			},
+			wantError: false,
+		},
+		{
+			name: "valid smtp with 100 char password (maximum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "username",
+				Password: strings.Repeat("p", 100),
+			},
+			wantError: false,
+		},
+		{
+			name: "invalid smtp with 2 char username (below minimum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "ab",
+				Password: "password",
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid smtp with 2 char password (below minimum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "username",
+				Password: "ab",
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid smtp with 101 char username (above maximum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: strings.Repeat("u", 101),
+				Password: "password",
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid smtp with 101 char password (above maximum)",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     587,
+				Username: "username",
+				Password: strings.Repeat("p", 101),
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid smtp with bad host",
+			smtp: SMTP{
+				Host:     "not a host",
+				Port:     0,
+				Username: "user",
+				Password: "pass",
+			},
+			wantError: true,
+		},
+		{
+			name: "invalid smtp with port above 65535",
+			smtp: SMTP{
+				Host:     "smtp.example.com",
+				Port:     70000,
+				Username: "user",
+				Password: "pass",
+			},
+			wantError: true,
+		},
 	}
-	bad := SMTP{Host: "not a host", Port: 0}
-	if err := bad.Validate(); err == nil {
-		t.Error("bad smtp must fail")
-	}
-	over := SMTP{Host: "smtp.example.com", Port: 70000}
-	if err := over.Validate(); err == nil {
-		t.Error("port >65535 must fail")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.smtp.Validate()
+			if (err != nil) != tt.wantError {
+				t.Errorf("SMTP.Validate() error = %v, wantError %v", err, tt.wantError)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

I am trying to add resend api as smtp server. it requires bigger than 20 characters limit on password field. this will fix it.

- Updated validation in internal/models/setting.go to allow 100 characters
- Added comprehensive table-driven tests for boundary validation
- Tests verify: minimum (3), typical (50), maximum (100), below min (2), above max (101)
- Follows pattern from other credential fields (Coinbase, Portone use 100-200)
- Database already supports TEXT type with no length constraint
- No breaking changes to existing SMTP configurations

Closes issue with SMTP credentials being too restrictive for modern authentication methods (e.g., app passwords, OAuth tokens).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If new dependencies exist, I have checked that they are really necessary and agreed with the maintainers/community (we want to have as few dependencies as possible)
- [x] I tried to make my code as fast as possible with as few allocations as possible
- [ ] For new code I have written benchmarks so that they can be analyzed and improved

## Commit formatting:

Use emojis on commit messages so it provides an easy way of identifying the purpose or intention of a commit. Check out the emoji cheatsheet here: https://gitmoji.carloscuesta.me/